### PR TITLE
Ensure single neighbor link

### DIFF
--- a/link.go
+++ b/link.go
@@ -138,6 +138,12 @@ func linkSingleObj(from XY, b *buildingData) {
 				} else {
 					autoEvents(neighbor.obj)
 				}
+
+				/*
+				 * Only allow one neighbor port to link to
+				 * this port.
+				 */
+				break
 			}
 		}
 		/* Run custom link code */


### PR DESCRIPTION
## Summary
- ensure link linking only happens once per neighboring object

## Testing
- `go vet ./...` *(fails: `fatal error: X11/extensions/Xrandr.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684deb4c9c04832a87680c175596b3db